### PR TITLE
auto_comment.yml changed to send different responses to owner's and …

### DIFF
--- a/.github/workflows/auto_comment.yml
+++ b/.github/workflows/auto_comment.yml
@@ -23,12 +23,19 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           issuesOpened: |
-            👋 @{{ author }}
+                {{#if eq github.repository.owner.login author}}
+                  👋 @{{ author }}
 
-            Thank you for raising this issue! We'll look into it ASAP.
+                  Thank you for raising this issue! We'll look into it ASAP.
 
-            Don't forget to give a ⭐️ & Happy coding!. 😊
+                  Don't forget to give a ⭐️ & Happy coding!. 😊
+                {{else}}
+                  👋 @{{ author }}
 
+                  Thank you for raising this issue! We'll look into it ASAP.
+
+                  As a contributor, we appreciate your help in improving this project! 😊
+                {{/if}}
       - name: Auto Comment on Issues Closed
         uses: wow-actions/auto-comment@v1
         with:


### PR DESCRIPTION
auto_comment.yml changed to send different responses to issues created by owners and contributors.
fixes #29 
I couldn't check if the change fixes the issue.
I have added an if statement which checks if the author is the owner or not and sends responses accordingly.
